### PR TITLE
JCF: update the single-repo CI workflow to better reflect how develop…

### DIFF
--- a/workflow-templates/dunedaq-develop-cpp-ci.yml
+++ b/workflow-templates/dunedaq-develop-cpp-ci.yml
@@ -65,11 +65,10 @@ jobs:
       run: |
           export REPO=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')
           cd $GITHUB_WORKSPACE/dev-${{ matrix.os_name }}
-          source env.sh || true
-          test $REPO == "dbe" && spack load dbe || true
-          spack unload $REPO || true
+          source env.sh
+          test $REPO == "dbe" && spack load dbe
           cp -pr $GITHUB_WORKSPACE/DUNE-DAQ/$REPO $GITHUB_WORKSPACE/dev-${{ matrix.os_name }}/sourcecode
-          dbt-build # --unittest # --lint
+          dbt-build  # --unittest done elsewhere; --lint unavailable due to llvm being too large for images
 
     - name: upload build log file
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
…ers actually build an individual package (drop unnecessary spack unload call + unnecessary swallow-the-error technique of adding "|| true" to individual commands)