### PR TITLE
Johnfreeman/issue8 skip ci if push

### DIFF
--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -18,6 +18,11 @@ jobs:
       - id: check
         run: |
           if [[ "$CALLER_BRANCH" == "$TARGET_BRANCH" ]]; then
+
+            git remote show origin
+            git branch
+            git log -1
+            git log -1 --format=%ct
             echo "should_run=false" >> $GITHUB_OUTPUT
             echo "This appears to be triggered by a merge; single repo CI is effectively disabled"
             exit 0

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -32,13 +32,14 @@ jobs:
             commit_time=$( git log -1 --format=%ct )
             current_time=$( date +%s )
 
+            time_since_last_commit=$(( current_time - commit_time ))
             max_time_since_push=90
 
-            if (( $(( current_time - commit_time )) > $max_time_since_push )); then
+            if (( $time_since_last_commit > $max_time_since_push )); then
               echo "should_run=true" >> $GITHUB_OUTPUT
             else
               echo "should_run=false" >> $GITHUB_OUTPUT
-              echo "This appears to be triggered by a merge or a push; single repo CI is disabled for this case"
+              echo "Single repo CI will not proceed as this appears to be triggered by a merge or a push (last commit to $TARGET_BRANCH was $time_since_last_commit seconds ago)"
               exit 0
             fi
           fi
@@ -102,6 +103,11 @@ jobs:
             release_name=$( ls -tr /cvmfs/dunedaq-development.opensciencegrid.org/nightly/ | grep fddaq | tail -1 )
             dbt-create -n $release_name dev-${{ matrix.os_name }}
           fi
+
+    - name: checkout package for CI
+      uses: actions/checkout@v5
+      with:
+        path: ${{ github.repository }}
 
     - name: setup build env, build the repo against the development release
       run: |

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -15,19 +15,32 @@ jobs:
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
     steps:
+
+      - name: checkout package for CI
+        uses: actions/checkout@v5
+        with:
+          path: ${{ github.repository }}
+
       - id: check
         run: |
-          if [[ "$CALLER_BRANCH" == "$TARGET_BRANCH" ]]; then
-
-            git remote show origin
-            git branch
-            git log -1
-            git log -1 --format=%ct
-            echo "should_run=false" >> $GITHUB_OUTPUT
-            echo "This appears to be triggered by a merge; single repo CI is effectively disabled"
-            exit 0
-          else
+          if [[ "$CALLER_BRANCH" != "$TARGET_BRANCH" ]]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
+          else
+
+            cd $GITHUB_WORKSPACE/${{ github.repository }}
+            git checkout $TARGET_BRANCH
+            commit_time=$( git log -1 --format=%ct )
+            current_time=$( date +%s )
+
+            max_time_since_push=90
+
+            if (( $(( current_time - commit_time )) > $max_time_since_push )); then
+              echo "should_run=true" >> $GITHUB_OUTPUT
+            else
+              echo "should_run=false" >> $GITHUB_OUTPUT
+              echo "This appears to be triggered by a merge or a push; single repo CI is disabled for this case"
+              exit 0
+            fi
           fi
 
   Determine_image:
@@ -63,9 +76,7 @@ jobs:
       run:
         shell: bash
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Runs a single command using the runners shell
     
     - name: Checkout daq-release
       uses: actions/checkout@v5
@@ -92,11 +103,6 @@ jobs:
             dbt-create -n $release_name dev-${{ matrix.os_name }}
           fi
 
-    - name: checkout package for CI
-      uses: actions/checkout@v5
-      with:
-        path: ${{ github.repository }}
-    
     - name: setup build env, build the repo against the development release
       run: |
           BRANCH="$CALLER_BRANCH"

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -8,6 +8,7 @@ on:
 env:
   CALLER_BRANCH: ${{ github.head_ref || github.ref_name }}
   TARGET_BRANCH: ${{ github.base_ref || github.ref_name }}
+  START_TIME: $( date +%s )
 
 jobs:
   Should_run:
@@ -30,9 +31,8 @@ jobs:
             cd $GITHUB_WORKSPACE/${{ github.repository }}
             git checkout $TARGET_BRANCH
             commit_time=$( git log -1 --format=%ct )
-            current_time=$( date +%s )
 
-            time_since_last_commit=$(( current_time - commit_time ))
+            time_since_last_commit=$(( $START_TIME - commit_time ))
             max_time_since_push=90
 
             if (( $time_since_last_commit > $max_time_since_push )); then

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -10,7 +10,24 @@ env:
   TARGET_BRANCH: ${{ github.base_ref || github.ref_name }}
 
 jobs:
+  Should_run:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - id: check
+        run: |
+          if [[ "$CALLER_BRANCH" == "$TARGET_BRANCH" ]]; then
+            echo "should_run=false" >> $GITHUB_OUTPUT
+            echo "This appears to be triggered by a merge; single repo CI is effectively disabled"
+            exit 0
+          else
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          fi
+
   Determine_image:
+    needs: Should_run
+    if: needs.Should_run.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.set_image.outputs.image }}

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -8,7 +8,6 @@ on:
 env:
   CALLER_BRANCH: ${{ github.head_ref || github.ref_name }}
   TARGET_BRANCH: ${{ github.base_ref || github.ref_name }}
-  START_TIME: $( date +%s )
 
 jobs:
   Should_run:
@@ -31,8 +30,9 @@ jobs:
             cd $GITHUB_WORKSPACE/${{ github.repository }}
             git checkout $TARGET_BRANCH
             commit_time=$( git log -1 --format=%ct )
+            current_time=$( date +%s )
 
-            time_since_last_commit=$(( $START_TIME - commit_time ))
+            time_since_last_commit=$(( current_time - commit_time ))
             max_time_since_push=90
 
             if (( $time_since_last_commit > $max_time_since_push )); then


### PR DESCRIPTION
Disable single repo CI workflow if (1) it's not a PR and (2) the branch in question was modified less than 90 seconds prior (suggesting actuation from a push or merge, as opposed to a scheduled nightly or manual actuation)