### PR TITLE
Add linting to single-repo CI builds

### DIFF
--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -206,9 +206,7 @@ jobs:
           --json databaseId \
           --jq '.[0].databaseId')
 
-        # TODO: Remove hard-coding before merge
-        run_id=23444192414
-
+        echo "Comparing results to those from run_id=$run_id"
         echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
 
     - name: Download latest nightly linting results

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -1,5 +1,8 @@
 name: Single-Package CI Build
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -1,4 +1,4 @@
-name: Single-Package CI Build
+name: Single-Package CI Build and Linting
 
 permissions:
   contents: read
@@ -81,7 +81,6 @@ jobs:
         shell: bash
 
     steps:
-    
     - name: Checkout daq-release
       uses: actions/checkout@main
       with:
@@ -99,7 +98,6 @@ jobs:
       run: |
           echo "Caller branch is " "$CALLER_BRANCH"
           echo "Target branch is " "$TARGET_BRANCH"
-          export REPO=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')
 
           extra_dbt_args=""
           if [[ ${{ needs.determine_image.outputs.image }} =~ ^.*stable.* ]]; then
@@ -125,9 +123,6 @@ jobs:
           BRANCH="$CALLER_BRANCH"
 
           export REPO=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')
-          #cd $GITHUB_WORKSPACE/dev-${{ matrix.os_name }}
-
-          echo "Before script: $(pwd)"
 
           cat << EOF > build_and_lint_package.sh
           #!/bin/bash
@@ -135,14 +130,10 @@ jobs:
           source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
           setup_dbt latest
 
-          echo "Creating in container: $(pwd)"
           dbt-create ${{ steps.get_release_info.outputs.extra_dbt_args }} \
                      ${{ steps.get_release_info.outputs.release_name}} \
                      dev-${{ matrix.os_name }}
-
-          echo "Build area?: $(ls)"
           cd dev-${{ matrix.os_name }}
-          echo "Now in: $(pwd)"
           source env.sh
 
           cd sourcecode
@@ -178,10 +169,6 @@ jobs:
         name: build_log_${{ matrix.os_name }}
         path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/build*.log
 
-    - name: Troubleshoot event name
-      run: |
-        echo "Event name = ${{ inputs.caller_event_name }}"
-
     - name: set linting artifact name
       id: set_artifact_name
       run: |
@@ -189,7 +176,6 @@ jobs:
         if [[ "${{ inputs.caller_event_name }}" == "schedule" ]]; then
           linting_artifact_name="nightly_linting_results"
         fi
-        echo "linting_artifact_name=$linting_artifact_name"
         echo "linting_artifact_name=$linting_artifact_name" >> "$GITHUB_OUTPUT"
 
     - name: upload linting log file
@@ -212,27 +198,18 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        #run_id=$(gh run list \
-        #  --repo ${{ github.repository }} \
-        #  --workflow dunedaq-develop-cpp-ci.yml \
-        #  --event schedule \
-        #  --limit 1 \
-        #  --json databaseId \
-        #  --jq '.[0].databaseId')
+        run_id=$(gh run list \
+          --repo ${{ github.repository }} \
+          --workflow dunedaq-develop-cpp-ci.yml \
+          --event schedule \
+          --limit 1 \
+          --json databaseId \
+          --jq '.[0].databaseId')
 
-        # TODO: Hard-coding alert to a fake scheduled run with linting results
-        # Longer term, the nightly linting should upload linting results and the
-        # above expression should work
+        # TODO: Remove hard-coding before merge
         run_id=23444192414
 
         echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
-
-    - name: List artifacts on the target run
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        gh api repos/DUNE-DAQ/hdf5libs/actions/runs/${{ steps.latest_nightly.outputs.run_id }}/artifacts \
-          --jq '.artifacts[] | [.name, .expired, .size_in_bytes] | @tsv'
 
     - name: Download latest nightly linting results
       uses: actions/download-artifact@main
@@ -247,13 +224,6 @@ jobs:
       with:
         name: pull_request_linting_results
         path: pull_request_linting
-
-    - name: List contents
-      run: |
-        echo "Where am I?"
-        pwd
-        echo "What's here?"
-        ls -lrt
 
     - name: Compare linting results
       id: compare
@@ -273,9 +243,6 @@ jobs:
         diff_file_name=linting_diff.txt
         pr_linting_results_file=$(find pull_request_linting/ -name "*_linting.log" | tail -n 1)
         nightly_linting_results_file=$(find nightly_linting/ -name "*_linting.log" | tail -n 1)
-
-        echo "pr_linting_results_file=$pr_linting_results"
-        echo "nightly_linting_results_file=$nightly_linting_results"
 
         [[ -f "$pr_linting_results_file" ]] || echo "ERROR: No PR results file; exit 1"
         [[ -f "$nightly_linting_results_file" ]] || echo "ERROR: No nightly results file; exit 2"
@@ -299,7 +266,7 @@ jobs:
         fi
 
     - name: upload linting diff file
-      if: ${{ always() && steps.compare.outputs.diff_exists == 'true' }}
+      if: ${{ steps.compare.outputs.diff_exists == 'true' }}
       uses: actions/upload-artifact@main
       with:
         name: linting_diff

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -175,6 +175,10 @@ jobs:
         name: build_log_${{ matrix.os_name }}
         path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/build*.log
 
+    - name: Troubleshoot event name
+      run: |
+        echo "Event name = ${{ inputs.caller_event_name }}"
+
     - name: set linting artifact name
       id: set_artifact_name
       run: |

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -263,6 +263,7 @@ jobs:
             s#^/[^ ]*/(sourcecode/.*)#\1#;     # drop leading absolute path before sourcecode/
             s#:[0-9]+:[0-9]+:#:#g;             # drop :line:col:
             s#:[0-9]+:#:#g;                    # drop :line:
+            /^[ ]*[0-9]+[ ]\|/d;               # Remove lines starting with " line | "
             /^Total errors found:/d;           # drop summary
           ' "$1" |
           grep -E '\[[^][]+\]' |               # keep only lines with a [check]

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -168,7 +168,7 @@ jobs:
             -v "${GITHUB_WORKSPACE}:/ghw" \
             -w /ghw \
             ${{ needs.determine_image.outputs.image }} \
-            /ghw/dev-${{ matrix.os_name }}/build_and_lint_package.sh
+            /ghw/build_and_lint_package.sh
 
     - name: upload build log file
       uses: actions/upload-artifact@main

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -4,6 +4,13 @@ permissions:
   contents: read
 
 on:
+  workflow_dispatch:
+    inputs:
+      caller_event_name:
+        default: 'schedule'
+        type: string
+        description: "Enter 'pull_request' (without quotes) to compare results to latest nightly linting results."
+
   workflow_call:
     inputs:
       caller_event_name:

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -279,8 +279,8 @@ jobs:
         [[ -f "$pr_linting_results_file" ]] || echo "ERROR: No PR results file; exit 1"
         [[ -f "$nightly_linting_results_file" ]] || echo "ERROR: No nightly results file; exit 2"
 
-        nightly_norm = $(mktemp)
-        pr_norm = $(mktemp)
+        nightly_norm=$(mktemp)
+        pr_norm=$(mktemp)
 
         normalize_lint "$nightly_linting_results" > "$nightly_norm"
         normalize_lint "$pr_linting_results" > "$pr_norm"

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -220,7 +220,7 @@ jobs:
         # TODO: Hard-coding alert to a fake scheduled run with linting results
         # Longer term, the nightly linting should upload linting results and the
         # above expression should work
-        run_id=23493490741
+        run_id=23444192414
 
         echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -186,4 +186,4 @@ jobs:
       uses: actions/upload-artifact@main
       with:
         name: linting_results
-        path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/linting*/_linting.log
+        path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/linting*/*_linting.log

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -2,6 +2,11 @@ name: Single-Package CI Build
 
 on:
   workflow_call:
+    inputs:
+      caller_event_name:
+        required: true
+        type: string
+        description: "Flag to distinguish between e.g. schedule and pull request"
 
 env:
   CALLER_BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -87,7 +92,7 @@ jobs:
     - name: Pull build image
       run: docker pull ${{ needs.determine_image.outputs.image }}
         
-    - id: setup_dev_area
+    - id: get_release_info
       run: |
           echo "Caller branch is " "$CALLER_BRANCH"
           echo "Target branch is " "$TARGET_BRANCH"
@@ -96,15 +101,12 @@ jobs:
           extra_dbt_args=""
           if [[ ${{ needs.determine_image.outputs.image }} =~ ^.*stable.* ]]; then
             release_name=$( ls -tr /cvmfs/dunedaq.opensciencegrid.org/spack/releases/ | grep fddaq | tail -1 )
-            #dbt-create $release_name dev-${{ matrix.os_name }}
           elif [[ ${{ needs.determine_image.outputs.image }} =~ ^.*candidate.* ]]; then
             extra_dbt_args="-b candidate"
             release_name=$( ls -tr /cvmfs/dunedaq-development.opensciencegrid.org/candidates/ | grep fddaq | tail -1 )
-            #dbt-create -b candidate $release_name dev-${{ matrix.os_name }}
           else
             extra_dbt_args="-n"
             release_name=$( ls -tr /cvmfs/dunedaq-development.opensciencegrid.org/nightly/ | grep fddaq | tail -1 )
-            #dbt-create -n $release_name dev-${{ matrix.os_name }}
           fi
 
           echo "extra_dbt_args=$extra_dbt_args" >> "$GITHUB_OUTPUT"
@@ -131,8 +133,8 @@ jobs:
           setup_dbt latest
 
           echo "Creating in container: $(pwd)"
-          dbt-create ${{ steps.setup_dev_area.outputs.extra_dbt_args }} \
-                     ${{ steps.setup_dev_area.outputs.release_name}} \
+          dbt-create ${{ steps.get_release_info.outputs.extra_dbt_args }} \
+                     ${{ steps.get_release_info.outputs.release_name}} \
                      dev-${{ matrix.os_name }}
 
           echo "Build area?: $(ls)"
@@ -160,9 +162,6 @@ jobs:
 
           chmod +x build_and_lint_package.sh
 
-          echo "Where am I? $(pwd)"
-          echo "What's here? $(ls -l)"
-
           docker run --rm \
             -v /cvmfs:/cvmfs:shared \
             -v "${GITHUB_WORKSPACE}:/ghw" \
@@ -170,40 +169,81 @@ jobs:
             ${{ needs.determine_image.outputs.image }} \
             /ghw/build_and_lint_package.sh
 
-          echo "Post-container: where am I? $(pwd)"
-          echo "Post-container: what's here? $(ls -l)"
-
-          echo "Linting results?"
-          ls dev-${{ matrix.os_name }}/log/linting*/*_linting.log
-
     - name: upload build log file
       uses: actions/upload-artifact@main
       with:
         name: build_log_${{ matrix.os_name }}
         path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/build*.log
 
+    - name: set linting artifact name
+      id: set_artifact_name
+      run: |
+        linting_artifact_name="linting_results"
+        if [[ ${{ inputs.caller_event_name == 'schedule' }} ]]; then
+          linting_artifact_name="nightly_linting_results"
+        fi
+        echo "linting_artifact_name=$linting_artifact_name" >> "$GITHUB_OUTPUT"
+
     - name: upload linting log file
       uses: actions/upload-artifact@main
       with:
-        name: linting_results
+        name: ${{ steps.set_artifact_name.outputs.linting_artifact_name }}
         path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/linting*/*_linting.log
+  
+  compare_linting_results:
+    if: ${{ inputs.caller_event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
 
-    - name: Download nightly linting results
-      if: ${{ github.event_name == 'pull_request' }}
+    steps:
+    - name: Get ID of latest nightly run
+      id: latest_nightly
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        run_id=$(gh run list \
+          --repo ${{ github.repository }}
+          --workflow dunedaq-develop-cpp-ci.yml \
+          --event schedule \
+          --limit 1 \
+          --json databaseId \
+          --jq '.[0].databaseId')
+
+        echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+
+    - name: Download latest nightly linting results
       uses: actions/download-artifact@main
       with:
-        name: linting_results
-        path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/nightly_linting_results.log 
+        name: nightly_linting_results
+        run-id: ${{ steps.latest_nightly.outputs.run_id }}
 
-    - name: Compare to nightly linting results
-      if: ${{ github.event_name == 'pull_request' }}
+    - name: Download pull request linting results
+      uses: actions/download-artifact@main
+      with:
+        name: pull_request_linting_results
+
+    - name: Compare linting results
+      id: compare
+      continue-on-error: true
       run: |
+        diff_file_name=linting_diff.txt
         pr_linting_results_file=$(dev-${{ matrix.os_name }}/log/linting*/*_linting.log)
         nightly_linting_results_file=$(dev-${{ matrix.os_name }}/nightly_linting_results.log)
+
         [[ -f "$pr_linting_results_file" ]] || echo "ERROR: No PR results file; exit 1"
         [[ -f "$nightly_linting_results_file" ]] || echo "ERROR: No nightly results file; exit 2"
-        if ! diff "$pr_linting_results_file" "$nightly_linting_results_file" > linting_diff.txt; then
+
+        if ! diff "$pr_linting_results_file" "$nightly_linting_results_file" > "$diff_file_name"; then
           echo "ERROR: This PR introduces new linting errors:"
-          cat linting_diff.txt
+          cat "$diff_file_name"
+          echo "diff_file_name=$diff_file_name" >> "$GITHUB_OUTPUT"
           exit 1
         fi
+
+    - name: upload linting diff file
+      uses: actions/upload-artifact@main
+      with:
+        name: linting_diff
+        path: ${{ github.workspace }}/${{ steps.compare.outputs.diff_file_name }}

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -246,13 +246,23 @@ jobs:
       with:
         name: pull_request_linting_results
 
+    - name: List contents
+      run: |
+        echo "Where am I?"
+        pwd
+        echo "What's here?"
+        ls -lrt
+
     - name: Compare linting results
       id: compare
       continue-on-error: true
       run: |
         diff_file_name=linting_diff.txt
-        pr_linting_results_file=$(dev-${{ matrix.os_name }}/log/linting*/*_linting.log)
-        nightly_linting_results_file=$(dev-${{ matrix.os_name }}/nightly_linting_results.log)
+        pr_linting_results_file=$(find . -name *_linting.log)
+        nightly_linting_results_file=$(find . -name nightly_linting_results.log)
+
+        echo "pr_linting_results_file=$pr_linting_results"
+        echo "nightly_linting_results_file=$nightly_linting_results"
 
         [[ -f "$pr_linting_results_file" ]] || echo "ERROR: No PR results file; exit 1"
         [[ -f "$nightly_linting_results_file" ]] || echo "ERROR: No nightly results file; exit 2"

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -178,7 +178,7 @@ jobs:
     - name: set linting artifact name
       id: set_artifact_name
       run: |
-        linting_artifact_name="linting_results"
+        linting_artifact_name="pull_request_linting_results"
         if [[ ${{ inputs.caller_event_name == 'schedule' }} ]]; then
           linting_artifact_name="nightly_linting_results"
         fi
@@ -243,7 +243,8 @@ jobs:
         fi
 
     - name: upload linting diff file
+      if: steps.compare.outputs.diff_file_name
       uses: actions/upload-artifact@main
       with:
         name: linting_diff
-        path: ${{ github.workspace }}/${{ steps.compare.outputs.diff_file_name }}
+        path: ${{ steps.compare.outputs.diff_file_name }}

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -187,3 +187,23 @@ jobs:
       with:
         name: linting_results
         path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/linting*/*_linting.log
+
+    - name: Download nightly linting results
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: actions/download-artifact@main
+      with:
+        name: linting_results
+        path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/nightly_linting_results.log 
+
+    - name: Compare to nightly linting results
+      if: ${{ github.event_name == 'pull_request' }}
+      run: |
+        pr_linting_results_file=$(dev-${{ matrix.os_name }}/log/linting*/*_linting.log)
+        nightly_linting_results_file=$(dev-${{ matrix.os_name }}/nightly_linting_results.log)
+        [[ -f "$pr_linting_results_file" ]] || echo "ERROR: No PR results file; exit 1"
+        [[ -f "$nightly_linting_results_file" ]] || echo "ERROR: No nightly results file; exit 2"
+        if ! diff "$pr_linting_results_file" "$nightly_linting_results_file" > linting_diff.txt; then
+          echo "ERROR: This PR introduces new linting errors:"
+          cat linting_diff.txt
+          exit 1
+        fi

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -170,8 +170,20 @@ jobs:
             ${{ needs.determine_image.outputs.image }} \
             /ghw/build_and_lint_package.sh
 
+          echo "Post-container: where am I? $(pwd)"
+          echo "Post-container: what's here? $(ls -l)"
+
+          echo "Linting results?"
+          ls dev-${{ matrix.os_name }}/log/linting*/*_linting.log
+
     - name: upload build log file
       uses: actions/upload-artifact@main
       with:
         name: build_log_${{ matrix.os_name }}
         path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/build*.log
+
+    - name: upload linting log file
+      uses: actions/upload-artifact@main
+      with:
+        name: linting_results
+        path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/linting*/_linting.log

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -1,7 +1,5 @@
-name: build-develop
+name: Single-Package CI Build
 
-# Controls when the action will run. Workflow runs when manually triggered using the UI
-# or API.
 on:
   workflow_call:
 
@@ -64,15 +62,12 @@ jobs:
   Build_against_dev_release:
     needs: Determine_image
     name: build_against_dev_on_${{ matrix.os_name }}
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
           - image: ${{ needs.determine_image.outputs.image }}
             os_name: "a9"
-    container:
-      image: ${{ matrix.image }}
     defaults:
       run:
         shell: bash
@@ -84,6 +79,13 @@ jobs:
       with:
         repository: DUNE-DAQ/daq-release
         path: daq-release
+
+    - uses: cvmfs-contrib/github-action-cvmfs@v5
+      with:
+        cvmfs_repositories: 'dunedaq-development.opensciencegrid.org'
+
+    - name: Pull build image
+      run: docker pull ${{ needs.determine_image.outputs.image }}
         
     - name: setup dev area
       run: |
@@ -116,15 +118,18 @@ jobs:
           export REPO=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')
           cd $GITHUB_WORKSPACE/dev-${{ matrix.os_name }}
 
+          cat << EOF > build_and_lint_package.sh
+          #!/bin/bash
+
           . ./env.sh
           cd $DBT_AREA_ROOT/sourcecode
 
           if [[ "$CALLER_BRANCH" == "$TARGET_BRANCH" ]]; then
-            cp -pr $GITHUB_WORKSPACE/DUNE-DAQ/$REPO .
+            cp -pr /ghw/DUNE-DAQ/$REPO .
           else   # Someone opened a PR
             export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-            ../../daq-release/scripts/clone_all_packages_with_branch.py --branch $CALLER_BRANCH --package-group coredaq
-            ../../daq-release/scripts/clone_all_packages_with_branch.py --branch $CALLER_BRANCH --package-group fddaq
+            ./daq-release/scripts/clone_all_packages_with_branch.py --branch $CALLER_BRANCH --package-group coredaq
+            ./daq-release/scripts/clone_all_packages_with_branch.py --branch $CALLER_BRANCH --package-group fddaq
           fi
 
           if [[ -d "./dbe" ]]; then
@@ -133,7 +138,17 @@ jobs:
 
           dbt-workarea-env
           dbt-info sourcecode
-          dbt-build  # --unittest done elsewhere; --lint unavailable due to llvm being too large for images
+          dbt-build --lint
+          EOF
+
+          chmod +x build_and_lint_package.sh
+
+          docker run --rm \
+            -v /cvmfs:/cvmfs:shared \
+            -v "${GITHUB_WORKSPACE}:/ghw" \
+            -w /ghw \
+            ${{ needs.determine_image.outputs.image }} \
+            ./build_and_lint_package.sh
 
     - name: upload build log file
       uses: actions/upload-artifact@main

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -87,24 +87,28 @@ jobs:
     - name: Pull build image
       run: docker pull ${{ needs.determine_image.outputs.image }}
         
-    - name: setup dev area
+    - id: setup_dev_area
       run: |
           echo "Caller branch is " "$CALLER_BRANCH"
           echo "Target branch is " "$TARGET_BRANCH"
           export REPO=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')
-          source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
-          setup_dbt latest
 
+          extra_dbt_args=""
           if [[ ${{ needs.determine_image.outputs.image }} =~ ^.*stable.* ]]; then
             release_name=$( ls -tr /cvmfs/dunedaq.opensciencegrid.org/spack/releases/ | grep fddaq | tail -1 )
-            dbt-create $release_name dev-${{ matrix.os_name }}
+            #dbt-create $release_name dev-${{ matrix.os_name }}
           elif [[ ${{ needs.determine_image.outputs.image }} =~ ^.*candidate.* ]]; then
+            extra_dbt_args="-b candidate"
             release_name=$( ls -tr /cvmfs/dunedaq-development.opensciencegrid.org/candidates/ | grep fddaq | tail -1 )
-            dbt-create -b candidate $release_name dev-${{ matrix.os_name }}
+            #dbt-create -b candidate $release_name dev-${{ matrix.os_name }}
           else
+            extra_dbt_args="-n"
             release_name=$( ls -tr /cvmfs/dunedaq-development.opensciencegrid.org/nightly/ | grep fddaq | tail -1 )
-            dbt-create -n $release_name dev-${{ matrix.os_name }}
+            #dbt-create -n $release_name dev-${{ matrix.os_name }}
           fi
+
+          echo "extra_dbt_args=$extra_dbt_args" >> "$GITHUB_OUTPUT"
+          echo "release_name=$release_name"     >> "$GITHUB_OUTPUT"
 
     - name: checkout package for CI
       uses: actions/checkout@main
@@ -121,15 +125,23 @@ jobs:
           cat << EOF > build_and_lint_package.sh
           #!/bin/bash
 
-          . ./env.sh
-          cd $DBT_AREA_ROOT/sourcecode
+          source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
+          setup_dbt latest
 
+          dbt-create ${{ steps.setup_dev_area.outputs.extra_dbt_args }} \
+                     ${{ steps.setup_dev_area.outputs.release_name}} \
+                     dev-${{ matrix.os_name }}
+
+          cd dev-${{ matrix.os_name }}
+          source env.sh
+
+          cd sourcecode
           if [[ "$CALLER_BRANCH" == "$TARGET_BRANCH" ]]; then
             cp -pr /ghw/DUNE-DAQ/$REPO .
           else   # Someone opened a PR
             export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-            ./daq-release/scripts/clone_all_packages_with_branch.py --branch $CALLER_BRANCH --package-group coredaq
-            ./daq-release/scripts/clone_all_packages_with_branch.py --branch $CALLER_BRANCH --package-group fddaq
+            /ghw/daq-release/scripts/clone_all_packages_with_branch.py --branch $CALLER_BRANCH --package-group coredaq
+            /ghw/daq-release/scripts/clone_all_packages_with_branch.py --branch $CALLER_BRANCH --package-group fddaq
           fi
 
           if [[ -d "./dbe" ]]; then

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -143,12 +143,15 @@ jobs:
 
           chmod +x build_and_lint_package.sh
 
+          echo "Where am I? $(pwd)"
+          echo "What's here? $(ls -l)"
+
           docker run --rm \
             -v /cvmfs:/cvmfs:shared \
             -v "${GITHUB_WORKSPACE}:/ghw" \
             -w /ghw \
             ${{ needs.determine_image.outputs.image }} \
-            ./build_and_lint_package.sh
+            /ghw/dev-${{ matrix.os_name }}/build_and_lint_package.sh
 
     - name: upload build log file
       uses: actions/upload-artifact@main

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -205,7 +205,7 @@ jobs:
         GH_TOKEN: ${{ github.token }}
       run: |
         run_id=$(gh run list \
-          --repo ${{ github.repository }}
+          --repo ${{ github.repository }} \
           --workflow dunedaq-develop-cpp-ci.yml \
           --event schedule \
           --limit 1 \

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -209,13 +209,18 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        run_id=$(gh run list \
-          --repo ${{ github.repository }} \
-          --workflow dunedaq-develop-cpp-ci.yml \
-          --event schedule \
-          --limit 1 \
-          --json databaseId \
-          --jq '.[0].databaseId')
+        #run_id=$(gh run list \
+        #  --repo ${{ github.repository }} \
+        #  --workflow dunedaq-develop-cpp-ci.yml \
+        #  --event schedule \
+        #  --limit 1 \
+        #  --json databaseId \
+        #  --jq '.[0].databaseId')
+
+        # TODO: Hard-coding alert to a fake scheduled run with linting results
+        # Longer term, the nightly linting should upload linting results and the
+        # above expression should work
+        run_id=23493490741
 
         echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -227,9 +227,17 @@ jobs:
 
         echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
 
+    - name: List artifacts on the target run
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh api repos/DUNE-DAQ/hdf5libs/actions/runs/${{ steps.latest_nightly.outputs.run_id }}/artifacts \
+          --jq '.artifacts[] | [.name, .expired, .size_in_bytes] | @tsv'
+
     - name: Download latest nightly linting results
       uses: actions/download-artifact@main
       with:
+        github-token: ${{ github.token }}
         name: nightly_linting_results
         run-id: ${{ steps.latest_nightly.outputs.run_id }}
 

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -4,13 +4,6 @@ permissions:
   contents: read
 
 on:
-  workflow_dispatch:
-    inputs:
-      caller_event_name:
-        default: 'schedule'
-        type: string
-        description: "Enter 'pull_request' (without quotes) to compare results to latest nightly linting results."
-
   workflow_call:
     inputs:
       caller_event_name:

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -257,8 +257,18 @@ jobs:
 
     - name: Compare linting results
       id: compare
-      continue-on-error: true
       run: |
+        normalize_lint() {
+          sed -E '
+            s#^/[^ ]*/(sourcecode/.*)#\1#;     # drop leading absolute path before sourcecode/
+            s#:[0-9]+:[0-9]+:#:#g;             # drop :line:col:
+            s#:[0-9]+:#:#g;                    # drop :line:
+            /^Total errors found:/d;           # drop summary
+          ' "$1" |
+          grep -E '\[[^][]+\]' |               # keep only lines with a [check]
+          sort -u
+        }
+
         diff_file_name=linting_diff.txt
         pr_linting_results_file=$(find pull_request_linting/ -name "*_linting.log" | tail -n 1)
         nightly_linting_results_file=$(find nightly_linting/ -name "*_linting.log" | tail -n 1)
@@ -269,15 +279,26 @@ jobs:
         [[ -f "$pr_linting_results_file" ]] || echo "ERROR: No PR results file; exit 1"
         [[ -f "$nightly_linting_results_file" ]] || echo "ERROR: No nightly results file; exit 2"
 
-        if ! diff "$pr_linting_results_file" "$nightly_linting_results_file" > "$diff_file_name"; then
+        nightly_norm = $(mktemp)
+        pr_norm = $(mktemp)
+
+        normalize_lint "$nightly_linting_results" > "$nightly_norm"
+        normalize_lint "$pr_linting_results" > "$pr_norm"
+
+        comm -13 "$nightly_norm" "$pr_norm" > "$diff_file_name"
+
+        if [[ -s "$diff_file_name" ]]; then
           echo "ERROR: This PR introduces new linting errors:"
           cat "$diff_file_name"
+          echo "diff_exists=true" >> "$GITHUB_OUTPUT"
           echo "diff_file_name=$diff_file_name" >> "$GITHUB_OUTPUT"
           exit 1
+        else
+          diff_exists="false"
         fi
 
     - name: upload linting diff file
-      if: steps.compare.outputs.diff_file_name
+      if: ${{ always() && steps.compare.outputs.diff_exists == 'true' }}
       uses: actions/upload-artifact@main
       with:
         name: linting_diff

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -282,8 +282,8 @@ jobs:
         nightly_norm=$(mktemp)
         pr_norm=$(mktemp)
 
-        normalize_lint "$nightly_linting_results" > "$nightly_norm"
-        normalize_lint "$pr_linting_results" > "$pr_norm"
+        normalize_lint "$nightly_linting_results_file" > "$nightly_norm"
+        normalize_lint "$pr_linting_results_file" > "$pr_norm"
 
         comm -13 "$nightly_norm" "$pr_norm" > "$diff_file_name"
 

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -183,9 +183,10 @@ jobs:
       id: set_artifact_name
       run: |
         linting_artifact_name="pull_request_linting_results"
-        if [[ ${{ inputs.caller_event_name == 'schedule' }} ]]; then
+        if [[ "${{ inputs.caller_event_name }}" == "schedule" ]]; then
           linting_artifact_name="nightly_linting_results"
         fi
+        echo "linting_artifact_name=$linting_artifact_name"
         echo "linting_artifact_name=$linting_artifact_name" >> "$GITHUB_OUTPUT"
 
     - name: upload linting log file

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -239,12 +239,14 @@ jobs:
       with:
         github-token: ${{ github.token }}
         name: nightly_linting_results
+        path: nightly_linting
         run-id: ${{ steps.latest_nightly.outputs.run_id }}
 
     - name: Download pull request linting results
       uses: actions/download-artifact@main
       with:
         name: pull_request_linting_results
+        path: pull_request_linting
 
     - name: List contents
       run: |
@@ -258,8 +260,8 @@ jobs:
       continue-on-error: true
       run: |
         diff_file_name=linting_diff.txt
-        pr_linting_results_file=$(find . -name *_linting.log)
-        nightly_linting_results_file=$(find . -name nightly_linting_results.log)
+        pr_linting_results_file=$(find pull_request_linting/ -name "*_linting.log" | tail -n 1)
+        nightly_linting_results_file=$(find nightly_linting/ -name "*_linting.log" | tail -n 1)
 
         echo "pr_linting_results_file=$pr_linting_results"
         echo "nightly_linting_results_file=$nightly_linting_results"

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -120,7 +120,9 @@ jobs:
           BRANCH="$CALLER_BRANCH"
 
           export REPO=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')
-          cd $GITHUB_WORKSPACE/dev-${{ matrix.os_name }}
+          #cd $GITHUB_WORKSPACE/dev-${{ matrix.os_name }}
+
+          echo "Before script: $(pwd)"
 
           cat << EOF > build_and_lint_package.sh
           #!/bin/bash
@@ -128,11 +130,14 @@ jobs:
           source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
           setup_dbt latest
 
+          echo "Creating in container: $(pwd)"
           dbt-create ${{ steps.setup_dev_area.outputs.extra_dbt_args }} \
                      ${{ steps.setup_dev_area.outputs.release_name}} \
                      dev-${{ matrix.os_name }}
 
+          echo "Build area?: $(ls)"
           cd dev-${{ matrix.os_name }}
+          echo "Now in: $(pwd)"
           source env.sh
 
           cd sourcecode

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -192,6 +192,7 @@ jobs:
   
   compare_linting_results:
     if: ${{ inputs.caller_event_name == 'pull_request' }}
+    needs: Build_against_dev_release
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/workflow-templates/dunedaq-develop-cpp-ci.yml
+++ b/workflow-templates/dunedaq-develop-cpp-ci.yml
@@ -1,7 +1,5 @@
 name: build-develop
 
-# Controls when the action will run. Workflow runs when manually triggered using the UI
-# or API.
 on:
   push:
     branches: 
@@ -26,3 +24,5 @@ jobs:
   build_develop_dispatch:
     name: Build against the development release
     uses: DUNE-DAQ/.github/.github/workflows/dunedaq-develop-cpp-ci.yml@develop
+    with:
+      caller_event_name: ${{ github.event_name }}

--- a/workflow-templates/dunedaq-develop-cpp-ci.yml
+++ b/workflow-templates/dunedaq-develop-cpp-ci.yml
@@ -1,4 +1,4 @@
-name: build-develop
+name: Single-Package CI Build and Linting
 
 on:
   push:
@@ -19,10 +19,15 @@ on:
     - cron: "0 9 * * *"
 
   workflow_dispatch:
+    inputs:
+      caller_event_name:
+        type: string
+        default: 'schedule'
+        description: "Enter 'pull_request' (without quotes) to compare linting results to previous linting results."
 
 jobs:
   build_develop_dispatch:
     name: Build against the development release
     uses: DUNE-DAQ/.github/.github/workflows/dunedaq-develop-cpp-ci.yml@develop
     with:
-      caller_event_name: ${{ github.event_name }}
+      caller_event_name: ${{ github.event.inputs.caller_event_name || github.event_name }}


### PR DESCRIPTION
This PR enables the single-repo CI builds to run `dbt-build --lint`. This is largely modeled off [Eric's implementation in artdaq](https://github.com/art-daq/.github/blob/stable/.github/workflows/artdaq-build-single-pkg.yml). The idea is to catch new linting errors introduced by pull requests without raising all previous linting errors (there are a lot in most repos). The nightly CI build will now upload an artifact called `nightly_linting_results`. Builds triggered by pull requests will upload `pull_request_linting_results` and then compare this to the most recent `nightly_linting_results`. If the `diff` (or, to be more precise, `comm -13`) between the two is non-empty, the workflow will raise an error and upload `linting_diff` as an artifact.

Notable changes:
- Add `caller_event_name` as a required input. This is necessary to distinguish scheduled (nightly) builds from those triggered by pull requests. Note that this means I'll need to sync the workflow files in each repository after this PR is merged.
- Use `cvmfs-contrib/github-action-cvmfs` to access CVMFS and, by extension, `llvm`.
- Write a `build_and_lint_package.sh` script and run it in the appropriate container.
- Use `sed` magic to simplify linting output for a clean `diff`.

For tests, see [this example](https://github.com/DUNE-DAQ/hdf5libs/actions/runs/23557034516) triggered by dummy pull request [#136 in hdf5libs](https://github.com/DUNE-DAQ/hdf5libs/pull/136). For comparison, [here](https://github.com/DUNE-DAQ/hdf5libs/actions/runs/23804275266) is a scheduled test which mocks the nightly workflow, but uses this feature branch to include linting.