### PR TITLE
Better specify linting comparison files

### DIFF
--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -71,6 +71,8 @@ jobs:
     needs: Determine_image
     name: build_against_dev_on_${{ matrix.os_name }}
     runs-on: ubuntu-latest
+    env:
+      REPO: ${{ github.event.repository.name }}
     strategy:
       matrix:
         include:
@@ -121,8 +123,6 @@ jobs:
     - name: setup build env, build the repo against the development release
       run: |
           BRANCH="$CALLER_BRANCH"
-
-          export REPO=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')
 
           cat << EOF > build_and_lint_package.sh
           #!/bin/bash
@@ -188,6 +188,8 @@ jobs:
     if: ${{ inputs.caller_event_name == 'pull_request' }}
     needs: Build_against_dev_release
     runs-on: ubuntu-latest
+    env:
+      REPO: ${{ github.event.repository.name }}
     defaults:
       run:
         shell: bash
@@ -239,8 +241,8 @@ jobs:
         }
 
         diff_file_name=linting_diff.txt
-        pr_linting_results_file=$(find pull_request_linting/ -name "*_linting.log" | tail -n 1)
-        nightly_linting_results_file=$(find nightly_linting/ -name "*_linting.log" | tail -n 1)
+        pr_linting_results_file=$(find pull_request_linting/ -name "$REPO_linting.log" | tail -n 1)
+        nightly_linting_results_file=$(find nightly_linting/ -name "$REPO_linting.log" | tail -n 1)
 
         [[ -f "$pr_linting_results_file" ]] || echo "ERROR: No PR results file; exit 1"
         [[ -f "$nightly_linting_results_file" ]] || echo "ERROR: No nightly results file; exit 2"

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -14,6 +14,7 @@ on:
 env:
   CALLER_BRANCH: ${{ github.head_ref || github.ref_name }}
   TARGET_BRANCH: ${{ github.base_ref || github.ref_name }}
+  REPO: ${{ github.event.repository.name }}
 
 jobs:
   Should_run:
@@ -71,8 +72,6 @@ jobs:
     needs: Determine_image
     name: build_against_dev_on_${{ matrix.os_name }}
     runs-on: ubuntu-latest
-    env:
-      REPO: ${{ github.event.repository.name }}
     strategy:
       matrix:
         include:
@@ -188,8 +187,6 @@ jobs:
     if: ${{ inputs.caller_event_name == 'pull_request' }}
     needs: Build_against_dev_release
     runs-on: ubuntu-latest
-    env:
-      REPO: ${{ github.event.repository.name }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -241,8 +241,8 @@ jobs:
         }
 
         diff_file_name=linting_diff.txt
-        pr_linting_results_file=$(find pull_request_linting/ -name "$REPO_linting.log" | tail -n 1)
-        nightly_linting_results_file=$(find nightly_linting/ -name "$REPO_linting.log" | tail -n 1)
+        pr_linting_results_file=$(find pull_request_linting/ -name "${REPO}_linting.log" | tail -n 1)
+        nightly_linting_results_file=$(find nightly_linting/ -name "${REPO}_linting.log" | tail -n 1)
 
         [[ -f "$pr_linting_results_file" ]] || echo "ERROR: No PR results file; exit 1"
         [[ -f "$nightly_linting_results_file" ]] || echo "ERROR: No nightly results file; exit 2"


### PR DESCRIPTION
In DUNE-DAQ/dfmodules#485, Kurt noticed that the linting comparison check was failing despite only integration test files being changed. I learned that this was because of greedy wildcard expansion in the `find` command which sets the file names for comparison. This wasn't caught in testing because I didn't test a case where multiple correlated PRs are built together, meaning `find` was finding multiple linting log files. The solution is to simply use the `$REPO` environment variable (now moved to workflow-level scope) when finding log files.

Initial failed run [here](https://github.com/DUNE-DAQ/dfmodules/actions/runs/24360730634)
Successful run using this branch [here](https://github.com/DUNE-DAQ/dfmodules/actions/runs/24411443224)