### PR TITLE
Add action for checking links in docs

### DIFF
--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -285,3 +285,15 @@ jobs:
       with:
         name: linting_diff
         path: ${{ steps.compare.outputs.diff_file_name }}
+
+  check_docs_links:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+    - uses: actions/checkout@v6
+    - name: Check links
+      uses: lycheeverse/lychee-action@v2
+      with:
+        fail: false

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -297,3 +297,9 @@ jobs:
       uses: lycheeverse/lychee-action@v2
       with:
         fail: false
+
+    - name: Upload link checker log
+      uses: actions/upload-artifact@v7
+      with:
+        name: link_checker_log
+        path: ./lychee/out.md

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -241,7 +241,7 @@ jobs:
             /^[ ]*[0-9]+[ ]\|/d;               # Remove lines starting with " line | "
             /^Total errors found:/d;           # drop summary
           ' "$1" |
-          grep -E '\[[^][]+\]' |               # keep only lines with a [check]
+          { grep -E '\[[^][]+\]' || true; }    # keep only lines with a [check]
           sort -u
         }
 

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -294,7 +294,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Check links
-      uses: lycheeverse/lychee-action@v2
+      uses: lycheeverse/lychee-action@6da1d14f3a43098a294b7696d93d938aa8d20fc0
       with:
         fail: false
 


### PR DESCRIPTION
This PR adds `lycheeverse/lychee-action` for checking links in documentation. For now, the output is only in the workflow summary, but I plan to add a job/step for automatically opening a GitHub issue once we solicit feedback on the basic output. See for example this [appfwk run](https://github.com/DUNE-DAQ/appfwk/actions/runs/26039606761) which includes the link checker output in the workflow summary.

Note that I'll need to add `lycheeverse/lychee-action@6da1d14f3a43098a294b7696d93d938aa8d20fc0` to [the allowed actions](https://github.com/DUNE-DAQ/org-admin/blob/develop/protection-rules/allowed_actions.json) and run the script which sets the allowed actions across repos.