### PR TITLE
Run unit tests and clang formatting as part of single-package CI build

### DIFF
--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -190,6 +190,33 @@ jobs:
         name: build_log_${{ matrix.os_name }}
         path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/build*.log
 
+    - name: Run unit tests
+      run: |
+        # The USER environment variable needs to be set for
+        # hdf5libs unit tests to pass
+        docker run --rm \
+          --user $(id -u):$(id -g) \
+          -v /cvmfs:/cvmfs:shared \
+          -v "${GITHUB_WORKSPACE}:/ghw" \
+          -e USER=dunedaq \
+          -w /ghw \
+          ${{ needs.determine_image.outputs.image }} \
+          /ghw/dbt_wrapper.sh dbt-build --unittest $REPO
+
+    - name: Get unit test summary path
+      id: unit_test_summary
+      run: |
+        summary_file_path=$(find . -name unit_test_summary.log -type f)
+        ./daq-release/scripts/github-ci/parse_unit_test_summary.sh $summary_file_path | tee $GITHUB_STEP_SUMMARY
+        echo "summary_file_path=$summary_file_path" >> "$GITHUB_OUTPUT"
+
+    - name: upload unit test summary file
+      uses: actions/upload-artifact@v7
+      with:
+        if-no-files-found: error
+        name: unit_test_summary
+        path: ${{ steps.unit_test_summary.outputs.summary_file_path }}
+
     - name: Run linting
       run: |
         docker run --rm \
@@ -222,33 +249,6 @@ jobs:
       with:
         name: ${{ steps.set_artifact_name.outputs.linting_artifact_name }}
         path: ${{ steps.set_artifact_name.outputs.linting_file_path }}
-
-    - name: Run unit tests
-      run: |
-        # The USER environment variable needs to be set for
-        # hdf5libs unit tests to pass
-        docker run --rm \
-          --user $(id -u):$(id -g) \
-          -v /cvmfs:/cvmfs:shared \
-          -v "${GITHUB_WORKSPACE}:/ghw" \
-          -e USER=dunedaq \
-          -w /ghw \
-          ${{ needs.determine_image.outputs.image }} \
-          /ghw/dbt_wrapper.sh dbt-build --unittest $REPO
-
-    - name: Get unit test summary path
-      id: unit_test_summary
-      run: |
-        summary_file_path=$(find . -name unit_test_summary.log -type f)
-        ./daq-release/scripts/github-ci/parse_unit_test_summary.sh $summary_file_path | tee $GITHUB_STEP_SUMMARY
-        echo "summary_file_path=$summary_file_path" >> "$GITHUB_OUTPUT"
-
-    - name: upload unit test summary file
-      uses: actions/upload-artifact@v7
-      with:
-        if-no-files-found: error
-        name: unit_test_summary
-        path: ${{ steps.unit_test_summary.outputs.summary_file_path }}
 
     - name: Run clang formatting
       id: clang_format

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -221,6 +221,7 @@ jobs:
         docker run --rm \
           -v /cvmfs:/cvmfs:shared \
           -v "${GITHUB_WORKSPACE}:/ghw" \
+          -e USER=dunedaq \
           -w /ghw \
           ${{ needs.determine_image.outputs.image }} \
           /ghw/dbt_wrapper.sh dbt-build --unittest $REPO

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -251,13 +251,21 @@ jobs:
           ${{ needs.determine_image.outputs.image }} \
           /ghw/dbt_wrapper.sh \
           dbt-clang-format.sh sourcecode/$REPO --view-differences-only --markdown-summary
+
+    - name: Get unit test summary path
+      id: clang_format_summary
+      run: |
+        file_path=$(find . -name clang_format_summary_table.md -type f)
+        cat "$file_path" >> $GITHUB_STEP_SUMMARY
+        echo "file_path=$file_path" >> "$GITHUB_OUTPUT"
+        cat "$GITHUB_OUTPUT"
   
     - name: upload clang format summary file
       uses: actions/upload-artifact@v7
       with:
         if-no-files-found: error
-        name: unit_test_summary
-        path: clang_format_summary_table.md
+        name: clang_format_summary
+        path: ${{ steps.clang_format_summary.outputs.file_path }}
 
   compare_linting_results:
     if: ${{ inputs.caller_event_name == 'pull_request' }}

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -162,7 +162,7 @@ jobs:
         fi
 
         dbt-workarea-env
-        dbt-info sourcecode
+        dbt-build
         EOF
 
         chmod +x setup_build_area.sh
@@ -178,7 +178,13 @@ jobs:
         pwd
         ls -lrt
 
-    - name: Run dbt-build --lint
+    - name: upload build log file
+      uses: actions/upload-artifact@v7
+      with:
+        name: build_log_${{ matrix.os_name }}
+        path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/build*.log
+
+    - name: Run linting
       run: |
         docker run --rm \
           -v /cvmfs:/cvmfs:shared \
@@ -186,12 +192,6 @@ jobs:
           -w /ghw \
           ${{ needs.determine_image.outputs.image }} \
           /ghw/dbt_wrapper.sh dbt-build --lint $REPO
-
-    - name: upload build log file
-      uses: actions/upload-artifact@v7
-      with:
-        name: build_log_${{ matrix.os_name }}
-        path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/build*.log
 
     - name: set linting artifact name
       id: set_artifact_name
@@ -215,6 +215,29 @@ jobs:
       with:
         name: ${{ steps.set_artifact_name.outputs.linting_artifact_name }}
         path: ${{ steps.set_artifact_name.outputs.linting_file_path }}
+
+    - name: Run unit tests
+      run: |
+        docker run --rm \
+          -v /cvmfs:/cvmfs:shared \
+          -v "${GITHUB_WORKSPACE}:/ghw" \
+          -w /ghw \
+          ${{ needs.determine_image.outputs.image }} \
+          /ghw/dbt_wrapper.sh dbt-build --unittest $REPO
+
+    - name: Get unit test summary path
+      id: unit_test_summary
+      run: |
+        summary_file_path=$(find . -name unit_test_summary.log -type f)
+        ./daq-release/scripts/github-ci/parse_unit_test_summary.sh $summary_file_path | tee $GITHUB_STEP_SUMMARY
+        echo "summary_file_path=$summary_file_path" >> "$GITHUB_OUTPUT"
+
+    - name: upload unit test summary file
+      uses: actions/upload-artifact@v7
+      with:
+        if-no-files-found: error
+        name: unit_test_summary
+        path: ${{ steps.unit_test_summary.outputs.summary_file_path }}
   
   compare_linting_results:
     if: ${{ inputs.caller_event_name == 'pull_request' }}

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -143,7 +143,7 @@ jobs:
         cat << EOF > setup_build_area.sh
         #!/bin/bash
 
-        set -euo pipefail
+        set -eo pipefail
 
         echo "---------pwd----------"
         pwd

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -295,9 +295,9 @@ jobs:
           --repo ${{ github.repository }} \
           --workflow dunedaq-develop-cpp-ci.yml \
           --event schedule \
-          --limit 1 \
-          --json databaseId \
-          --jq '.[0].databaseId')
+          --limit 10 \
+          --json databaseId,conclusion \
+          --jq '[.[] | select(.conclusion=="success")] | first | .databaseId')
 
         echo "Comparing results to those from run_id=$run_id"
         echo "run_id=$run_id" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -94,9 +94,7 @@ jobs:
 
     - name: Make workspace writeable for container user
       run: |
-        ls -lrt
         chmod -R o+w "${GITHUB_WORKSPACE}"
-        ls -lrt
 
     - name: Pull build image
       run: docker pull ${{ needs.determine_image.outputs.image }}
@@ -151,28 +149,16 @@ jobs:
 
         set -eo pipefail
 
-        echo "---------pwd----------"
-        pwd
-        echo "-------ls -lrt---------"
-        ls -lrt
-
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         setup_dbt latest
 
         # Need the -s flag to avoid permission issues with /.spack when running
         # inside a container as a non-root user
-        dbt-create -s ${{ steps.get_release_info.outputs.extra_dbt_args }} \
+        #dbt-create -s ${{ steps.get_release_info.outputs.extra_dbt_args }} \
+        dbt-create ${{ steps.get_release_info.outputs.extra_dbt_args }} \
                    ${{ steps.get_release_info.outputs.release_name}} \
                    dev-${{ matrix.os_name }} || exit 11
-        echo "---------pwd----------"
-        pwd
-        echo "-------ls -lrt---------"
-        ls -lrt
         cd dev-${{ matrix.os_name }}
-        echo "---------pwd----------"
-        pwd
-        echo "-------ls -lrt---------"
-        ls -lrt
         source env.sh
 
         cd sourcecode
@@ -198,9 +184,6 @@ jobs:
           -w /ghw \
           ${{ needs.determine_image.outputs.image }} \
           /ghw/setup_build_area.sh
-
-        pwd
-        ls -lrt
 
     - name: upload build log file
       uses: actions/upload-artifact@v7
@@ -243,6 +226,8 @@ jobs:
 
     - name: Run unit tests
       run: |
+        # The USER environment variable needs to be set for
+        # hdf5libs unit tests to pass
         docker run --rm \
           --user $(id -u):$(id -g) \
           -v /cvmfs:/cvmfs:shared \

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -92,6 +92,12 @@ jobs:
       with:
         cvmfs_repositories: 'dunedaq-development.opensciencegrid.org'
 
+    - name: Make workspace writeable for container user
+      run: |
+        ls -lrt
+        chmod -R o+w "${GITHUB_WORKSPACE}"
+        ls -lrt
+
     - name: Pull build image
       run: docker pull ${{ needs.determine_image.outputs.image }}
         
@@ -125,7 +131,7 @@ jobs:
         #!/bin/bash
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         setup_dbt latest
-        cd /tmp/dev-${{ matrix.os_name }}
+        cd /ghw/dev-${{ matrix.os_name }}
         source env.sh
         if [[ -d ".sourcecode/dbe" ]]; then
           spack load dbe
@@ -158,7 +164,15 @@ jobs:
         dbt-create -s ${{ steps.get_release_info.outputs.extra_dbt_args }} \
                    ${{ steps.get_release_info.outputs.release_name}} \
                    dev-${{ matrix.os_name }} || exit 11
+        echo "---------pwd----------"
+        pwd
+        echo "-------ls -lrt---------"
+        ls -lrt
         cd dev-${{ matrix.os_name }}
+        echo "---------pwd----------"
+        pwd
+        echo "-------ls -lrt---------"
+        ls -lrt
         source env.sh
 
         cd sourcecode
@@ -181,7 +195,7 @@ jobs:
           --user $(id -u):$(id -g) \
           -v /cvmfs:/cvmfs:shared \
           -v "${GITHUB_WORKSPACE}:/ghw" \
-          -w /tmp \
+          -w /ghw \
           ${{ needs.determine_image.outputs.image }} \
           /ghw/setup_build_area.sh
 
@@ -200,7 +214,7 @@ jobs:
           --user $(id -u):$(id -g) \
           -v /cvmfs:/cvmfs:shared \
           -v "${GITHUB_WORKSPACE}:/ghw" \
-          -w /tmp \
+          -w /ghw \
           ${{ needs.determine_image.outputs.image }} \
           /ghw/dbt_wrapper.sh dbt-build --lint $REPO
 
@@ -234,7 +248,7 @@ jobs:
           -v /cvmfs:/cvmfs:shared \
           -v "${GITHUB_WORKSPACE}:/ghw" \
           -e USER=dunedaq \
-          -w /tmp \
+          -w /ghw \
           ${{ needs.determine_image.outputs.image }} \
           /ghw/dbt_wrapper.sh dbt-build --unittest $REPO
 
@@ -259,7 +273,7 @@ jobs:
           -v /cvmfs:/cvmfs:shared \
           -v "${GITHUB_WORKSPACE}:/ghw" \
           -e USER=dunedaq \
-          -w /tmp \
+          -w /ghw \
           ${{ needs.determine_image.outputs.image }} \
           /ghw/dbt_wrapper.sh \
           dbt-clang-format.sh sourcecode/$REPO --view-differences-only --markdown-summary

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -154,8 +154,7 @@ jobs:
 
         # Need the -s flag to avoid permission issues with /.spack when running
         # inside a container as a non-root user
-        #dbt-create -s ${{ steps.get_release_info.outputs.extra_dbt_args }} \
-        dbt-create ${{ steps.get_release_info.outputs.extra_dbt_args }} \
+        dbt-create -s ${{ steps.get_release_info.outputs.extra_dbt_args }} \
                    ${{ steps.get_release_info.outputs.release_name}} \
                    dev-${{ matrix.os_name }} || exit 11
         cd dev-${{ matrix.os_name }}

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -119,48 +119,74 @@ jobs:
       with:
         path: ${{ github.repository }}
 
-    - name: setup build env, build the repo against the development release
+    - name: Generate dbt wrapper script
       run: |
-          BRANCH="$CALLER_BRANCH"
+        cat << 'EOF' > dbt_wrapper.sh
+        #!/bin/bash
+        source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
+        setup_dbt latest
+        cd /ghw/dev-${{ matrix.os_name }}
+        source env.sh
+        if [[ -d ".sourcecode/dbe" ]]; then
+          spack load dbe
+        fi
+        exec "$@"
+        EOF
+        
+        chmod +x dbt_wrapper.sh
+        cat dbt_wrapper.sh
 
-          cat << EOF > build_and_lint_package.sh
-          #!/bin/bash
+    - name: setup build area
+      run: |
+        BRANCH="$CALLER_BRANCH"
 
-          source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
-          setup_dbt latest
+        cat << EOF > setup_build_area.sh
+        #!/bin/bash
 
-          dbt-create ${{ steps.get_release_info.outputs.extra_dbt_args }} \
-                     ${{ steps.get_release_info.outputs.release_name}} \
-                     dev-${{ matrix.os_name }}
-          cd dev-${{ matrix.os_name }}
-          source env.sh
+        source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
+        setup_dbt latest
 
-          cd sourcecode
-          if [[ "$CALLER_BRANCH" == "$TARGET_BRANCH" ]]; then
-            cp -pr /ghw/DUNE-DAQ/$REPO .
-          else   # Someone opened a PR
-            export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-            /ghw/daq-release/scripts/clone_all_packages_with_branch.py --branch $CALLER_BRANCH --package-group coredaq
-            /ghw/daq-release/scripts/clone_all_packages_with_branch.py --branch $CALLER_BRANCH --package-group fddaq
-          fi
+        dbt-create ${{ steps.get_release_info.outputs.extra_dbt_args }} \
+                    ${{ steps.get_release_info.outputs.release_name}} \
+                    dev-${{ matrix.os_name }}
+        cd dev-${{ matrix.os_name }}
+        source env.sh
 
-          if [[ -d "./dbe" ]]; then
-            spack load dbe
-          fi
+        cd sourcecode
+        if [[ "$CALLER_BRANCH" == "$TARGET_BRANCH" ]]; then
+          cp -pr /ghw/DUNE-DAQ/$REPO .
+        else   # Someone opened a PR
+          export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          /ghw/daq-release/scripts/clone_all_packages_with_branch.py --branch $CALLER_BRANCH --package-group coredaq
+          /ghw/daq-release/scripts/clone_all_packages_with_branch.py --branch $CALLER_BRANCH --package-group fddaq
+        fi
 
-          dbt-workarea-env
-          dbt-info sourcecode
-          dbt-build --lint $REPO
-          EOF
+        dbt-workarea-env
+        dbt-info sourcecode
+        EOF
 
-          chmod +x build_and_lint_package.sh
+        chmod +x setup_build_area.sh
+        cat setup_build_area.sh
 
-          docker run --rm \
-            -v /cvmfs:/cvmfs:shared \
-            -v "${GITHUB_WORKSPACE}:/ghw" \
-            -w /ghw \
-            ${{ needs.determine_image.outputs.image }} \
-            /ghw/build_and_lint_package.sh
+        docker run --rm \
+          -v /cvmfs:/cvmfs:shared \
+          -v "${GITHUB_WORKSPACE}:/ghw" \
+          -w /ghw \
+          ${{ needs.determine_image.outputs.image }} \
+          /ghw/setup_build_area.sh
+
+        pwd
+        ls -lrt
+        ls -lrt /ghw
+
+    - name: Run dbt-build --lint
+      run: |
+        docker run --rm \
+          -v /cvmfs:/cvmfs:shared \
+          -v "${GITHUB_WORKSPACE}:/ghw" \
+          -w /ghw \
+          ${{ needs.determine_image.outputs.image }} \
+          /ghw/dbt_wrapper.sh dbt-build --lint $REPO
 
     - name: upload build log file
       uses: actions/upload-artifact@v7

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -1,4 +1,4 @@
-name: Single-Package CI Build and Linting
+name: Single-Package CI Build and Tests
 
 permissions:
   contents: read

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -146,9 +146,11 @@ jobs:
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         setup_dbt latest
 
-        dbt-create ${{ steps.get_release_info.outputs.extra_dbt_args }} \
-                    ${{ steps.get_release_info.outputs.release_name}} \
-                    dev-${{ matrix.os_name }}
+        # Need the -s flag to avoid permission issues with /.spack when running
+        # inside a container as a non-root user
+        dbt-create -s ${{ steps.get_release_info.outputs.extra_dbt_args }} \
+                   ${{ steps.get_release_info.outputs.release_name}} \
+                   dev-${{ matrix.os_name }}
         cd dev-${{ matrix.os_name }}
         source env.sh
 

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -157,7 +157,7 @@ jobs:
         # inside a container as a non-root user
         dbt-create -s ${{ steps.get_release_info.outputs.extra_dbt_args }} \
                    ${{ steps.get_release_info.outputs.release_name}} \
-                   dev-${{ matrix.os_name }} | exit 11
+                   dev-${{ matrix.os_name }} || exit 11
         cd dev-${{ matrix.os_name }}
         source env.sh
 

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -239,7 +239,26 @@ jobs:
         if-no-files-found: error
         name: unit_test_summary
         path: ${{ steps.unit_test_summary.outputs.summary_file_path }}
+
+    - name: Run clang formatting
+      id: clang_format
+      run: |
+        docker run --rm \
+          -v /cvmfs:/cvmfs:shared \
+          -v "${GITHUB_WORKSPACE}:/ghw" \
+          -e USER=dunedaq \
+          -w /ghw \
+          ${{ needs.determine_image.outputs.image }} \
+          /ghw/dbt_wrapper.sh \
+          dbt-clang-format.sh sourcecode/$REPO --view-differences-only --markdown-summary
   
+    - name: upload clang format summary file
+      uses: actions/upload-artifact@v7
+      with:
+        if-no-files-found: error
+        name: unit_test_summary
+        path: clang_format_summary_table.md
+
   compare_linting_results:
     if: ${{ inputs.caller_event_name == 'pull_request' }}
     needs: Build_against_dev_release

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -177,7 +177,6 @@ jobs:
 
         pwd
         ls -lrt
-        ls -lrt /ghw
 
     - name: Run dbt-build --lint
       run: |

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -143,6 +143,13 @@ jobs:
         cat << EOF > setup_build_area.sh
         #!/bin/bash
 
+        set -euo pipefail
+
+        echo "---------pwd----------"
+        pwd
+        echo "-------ls -lrt---------"
+        ls -lrt
+
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         setup_dbt latest
 
@@ -150,13 +157,13 @@ jobs:
         # inside a container as a non-root user
         dbt-create -s ${{ steps.get_release_info.outputs.extra_dbt_args }} \
                    ${{ steps.get_release_info.outputs.release_name}} \
-                   dev-${{ matrix.os_name }}
+                   dev-${{ matrix.os_name }} | exit 11
         cd dev-${{ matrix.os_name }}
         source env.sh
 
         cd sourcecode
         if [[ "$CALLER_BRANCH" == "$TARGET_BRANCH" ]]; then
-          cp -pr /tmp/DUNE-DAQ/$REPO .
+          cp -pr /ghw/DUNE-DAQ/$REPO .
         else   # Someone opened a PR
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           /ghw/daq-release/scripts/clone_all_packages_with_branch.py --branch $CALLER_BRANCH --package-group coredaq

--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -125,7 +125,7 @@ jobs:
         #!/bin/bash
         source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
         setup_dbt latest
-        cd /ghw/dev-${{ matrix.os_name }}
+        cd /tmp/dev-${{ matrix.os_name }}
         source env.sh
         if [[ -d ".sourcecode/dbe" ]]; then
           spack load dbe
@@ -154,7 +154,7 @@ jobs:
 
         cd sourcecode
         if [[ "$CALLER_BRANCH" == "$TARGET_BRANCH" ]]; then
-          cp -pr /ghw/DUNE-DAQ/$REPO .
+          cp -pr /tmp/DUNE-DAQ/$REPO .
         else   # Someone opened a PR
           export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           /ghw/daq-release/scripts/clone_all_packages_with_branch.py --branch $CALLER_BRANCH --package-group coredaq
@@ -169,9 +169,10 @@ jobs:
         cat setup_build_area.sh
 
         docker run --rm \
+          --user $(id -u):$(id -g) \
           -v /cvmfs:/cvmfs:shared \
           -v "${GITHUB_WORKSPACE}:/ghw" \
-          -w /ghw \
+          -w /tmp \
           ${{ needs.determine_image.outputs.image }} \
           /ghw/setup_build_area.sh
 
@@ -187,9 +188,10 @@ jobs:
     - name: Run linting
       run: |
         docker run --rm \
+          --user $(id -u):$(id -g) \
           -v /cvmfs:/cvmfs:shared \
           -v "${GITHUB_WORKSPACE}:/ghw" \
-          -w /ghw \
+          -w /tmp \
           ${{ needs.determine_image.outputs.image }} \
           /ghw/dbt_wrapper.sh dbt-build --lint $REPO
 
@@ -219,10 +221,11 @@ jobs:
     - name: Run unit tests
       run: |
         docker run --rm \
+          --user $(id -u):$(id -g) \
           -v /cvmfs:/cvmfs:shared \
           -v "${GITHUB_WORKSPACE}:/ghw" \
           -e USER=dunedaq \
-          -w /ghw \
+          -w /tmp \
           ${{ needs.determine_image.outputs.image }} \
           /ghw/dbt_wrapper.sh dbt-build --unittest $REPO
 
@@ -247,7 +250,7 @@ jobs:
           -v /cvmfs:/cvmfs:shared \
           -v "${GITHUB_WORKSPACE}:/ghw" \
           -e USER=dunedaq \
-          -w /ghw \
+          -w /tmp \
           ${{ needs.determine_image.outputs.image }} \
           /ghw/dbt_wrapper.sh \
           dbt-clang-format.sh sourcecode/$REPO --view-differences-only --markdown-summary


### PR DESCRIPTION
This PR partially addresses DUNE-DAQ/daq-release#544 by moving nightly code checks into the single-package CI builds. In addition to `dbt-build --lint`, this will also run `dbt-build --unittest` and `dbt-clang-format.sh` in the same container spun off the relevant image. In the interest of somewhat reducing code duplication, there's a dedicated step that generates a wrapper script which does the typical setup steps, e.g., `cd $DBT_AREA_ROOT && source env.sh` etc.

Running tests inside a container introduced a couple of quirks to do with permissions in Docker containers. To get around this, each `docker run` command now includes a `--user $(id -u):$(id -g)` to emulate a more typical non-root user experience. This in turn requires explicitly allowing others to write to the `$GITHUB_WORKSPACE`.

All artifacts are uploaded just as in the nightly code check workflow. Eventually, I want the CI dashboard workflow to pull these single-repo artifacts and structure the dashboard around individual repos rather than giant lists of tests. But for now, the nightly code checks and CI dashboard will proceed as normal until I implement this.

I primarily tested this using `opmonlib` since one of its unit tests attempts to write to a root area and expects an exception to be thrown.

Successful test in `opmonlib`: https://github.com/DUNE-DAQ/opmonlib/actions/runs/28816083789